### PR TITLE
feat: enable cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
 		"test": "vitest"
 	},
 	"dependencies": {
-		"@hono/swagger-ui": "^0.5.2",
 		"hono": "^4.10.7"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@hono/swagger-ui':
-        specifier: ^0.5.2
-        version: 0.5.2(hono@4.10.7)
       hono:
         specifier: ^4.10.7
         version: 4.10.7
@@ -445,11 +442,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@hono/swagger-ui@0.5.2':
-    resolution: {integrity: sha512-7wxLKdb8h7JTdZ+K8DJNE3KXQMIpJejkBTQjrYlUWF28Z1PGOKw6kUykARe5NTfueIN37jbyG/sBYsbzXzG53A==}
-    peerDependencies:
-      hono: '*'
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -1351,10 +1343,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.4':
     optional: true
-
-  '@hono/swagger-ui@0.5.2(hono@4.10.7)':
-    dependencies:
-      hono: 4.10.7
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="SwaggerUI" />
+		<title>SwaggerUI</title>
+	</head>
+	<body>
+		<div>
+			<div id="swagger-ui"></div>
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css" />
+			<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+			<script>
+				window.onload = () => {
+				  window.ui = SwaggerUIBundle({
+				    dom_id: '#swagger-ui',url: '/spec.json',
+				  })
+				}
+			</script>
+		</div>
+	</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
 
 import { anything } from "./routes/anything";
@@ -30,15 +29,6 @@ app.get("/spec.json", async (c) => {
 		},
 	});
 });
-
-app.get(
-	"/",
-	async (c, next) => {
-		await next();
-		c.header("Cache-Control", "public, max-age=86400, immutable");
-	},
-	swaggerUI({ url: "/spec.json" }),
-);
 
 app.route("/", httpMethods);
 app.route("/", statusCodes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ app.get("/spec.json", async (c) => {
 
 	return c.json(spec, {
 		headers: {
-			"Cache-Control": "public, max-age=86400",
+			"Cache-Control": "public, max-age=604800",
 		},
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,10 +24,21 @@ app.get("/spec.json", async (c) => {
 	spec.schemes =
 		new URL(c.req.url).protocol === "https:" ? ["https"] : ["http"];
 
-	return c.json(spec);
+	return c.json(spec, {
+		headers: {
+			"Cache-Control": "public, max-age=86400",
+		},
+	});
 });
 
-app.get("/", swaggerUI({ url: "/spec.json" }));
+app.get(
+	"/",
+	async (c, next) => {
+		await next();
+		c.header("Cache-Control", "public, max-age=86400, immutable");
+	},
+	swaggerUI({ url: "/spec.json" }),
+);
 
 app.route("/", httpMethods);
 app.route("/", statusCodes);

--- a/test/routes/cookies.test.ts
+++ b/test/routes/cookies.test.ts
@@ -388,7 +388,9 @@ describe("Cookies", () => {
 	describe("Secure cookie detection", () => {
 		it("should detect HTTPS from URL protocol", async () => {
 			// Test with HTTPS URL by creating a Request with HTTPS URL
-			const httpsRequest = new Request("https://example.com/cookies/set/foo/bar");
+			const httpsRequest = new Request(
+				"https://example.com/cookies/set/foo/bar",
+			);
 			const res = await cookies.fetch(httpsRequest, env);
 
 			expect(res.status).toBe(302);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Serve Swagger UI from a new static `public/index.html` and add caching headers to `/spec.json`, removing `@hono/swagger-ui` usage and dependency.
> 
> - **API**:
>   - Add `Cache-Control: public, max-age=604800` to `/spec.json` response.
>   - Remove `app.get("/", swaggerUI({ url: "/spec.json" }))`.
> - **UI/Docs**:
>   - Add static `public/index.html` that loads Swagger UI from CDN and points to `/spec.json`.
> - **Dependencies**:
>   - Remove `@hono/swagger-ui` from `package.json` and lockfile.
> - **Tests**:
>   - Minor formatting only in `test/routes/cookies.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52c5fb63b29b5c199368f051f09a244cbc30279e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->