### PR TITLE
Check ワークフロー失敗の修正（TypeScript・Biome・クッキー名）

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@cloudflare/vitest-pool-workers": "^0.14.3",
+        "typescript": "^5.8.3",
         "vitest": "^4.1.4",
         "wrangler": "^4.81.1",
       },
@@ -324,6 +325,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.11",
 		"@cloudflare/vitest-pool-workers": "^0.14.3",
+		"typescript": "^5.8.3",
 		"vitest": "^4.1.4",
 		"wrangler": "^4.81.1"
 	},

--- a/src/routes/authentication.ts
+++ b/src/routes/authentication.ts
@@ -8,7 +8,7 @@ export const authentication = new Hono();
  * Parse Digest authorization header
  */
 function parseDigestAuth(authHeader: string): Record<string, string> | null {
-	if (!authHeader || !authHeader.startsWith("Digest ")) {
+	if (!authHeader?.startsWith("Digest ")) {
 		return null;
 	}
 
@@ -184,7 +184,7 @@ authentication.get("/basic-auth/:user/:passwd", async (c) => {
 
 	const authHeader = c.req.header("authorization");
 
-	if (!authHeader || !authHeader.startsWith("Basic ")) {
+	if (!authHeader?.startsWith("Basic ")) {
 		return c.body(null, 401, {
 			"WWW-Authenticate": 'Basic realm="Fake Realm"',
 		});
@@ -210,7 +210,7 @@ authentication.get("/basic-auth/:user/:passwd", async (c) => {
 authentication.get("/bearer", (c) => {
 	const authHeader = c.req.header("authorization");
 
-	if (!authHeader || !authHeader.startsWith("Bearer ")) {
+	if (!authHeader?.startsWith("Bearer ")) {
 		return c.body(null, 401, { "WWW-Authenticate": "Bearer" });
 	}
 

--- a/src/routes/cookies.ts
+++ b/src/routes/cookies.ts
@@ -8,6 +8,13 @@ export const cookies = new Hono();
 
 // Environment cookies that should be hidden by default
 // Original: https://github.com/postmanlabs/httpbin/blob/f8ec666b4d1b654e4ff6aedd356f510dcac09f83/httpbin/core.py#L60
+// Hono rejects cookie names outside token / RFC6265-ish charset (see hono/utils/cookie).
+const VALID_COOKIE_NAME = /^[\w!#$%&'*.^`|~+-]+$/;
+
+function encodeCookieNameIfNeeded(name: string): string {
+	return VALID_COOKIE_NAME.test(name) ? name : encodeURIComponent(name);
+}
+
 const ENV_COOKIES = [
 	"_gauges_unique",
 	"_gauges_unique_year",
@@ -56,7 +63,7 @@ cookies.get("/cookies/set/:name/:value", (c) => {
 	const name = c.req.param("name");
 	const value = c.req.param("value");
 
-	setCookie(c, name, value, {
+	setCookie(c, encodeCookieNameIfNeeded(name), value, {
 		path: "/",
 		httpOnly: false,
 		secure: secureCookie(c),
@@ -73,7 +80,7 @@ cookies.get("/cookies/set", (c) => {
 
 	Object.entries(params).forEach(([name, value]) => {
 		// biome-ignore lint/style/noNonNullAssertion: value is not empty
-		setCookie(c, name, value[0]!, {
+		setCookie(c, encodeCookieNameIfNeeded(name), value[0]!, {
 			path: "/",
 			httpOnly: false,
 			secure: secureCookie(c),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

GitHub Actions の `Check` ジョブが通るように、型チェック・Lint・テストで落ちていた点を修正しました。

## 変更内容

- **`check-types`**: `tsc` がプロジェクトに含まれておらず CI で `command not found` になっていたため、`typescript` を devDependency に追加しました。
- **`bun run check` (Biome)**: `authentication.ts` の `useOptionalChain` 警告を解消しました。
- **`bun run test`**: パスに `%20` を含むクッキー名がデコードされスペースを含むと、Hono の `setCookie` が「Invalid cookie name」で 500 になっていたため、許可されない名前は `encodeURIComponent` してから `setCookie` に渡すようにしました（値は従来どおり Hono 側でエンコードされます）。

## 検証

ローカルで `bun install --frozen-lockfile`、`bun run check`、`bun run check-types`、`bun run test` を実行し、すべて成功することを確認しました。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-761e5f23-f3e4-49dc-ae8d-b30e8ecc7466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-761e5f23-f3e4-49dc-ae8d-b30e8ecc7466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

