### PR TITLE
fix(ci): add TypeScript for typecheck and align cookie tests with Hono

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@cloudflare/vitest-pool-workers": "^0.14.3",
+        "typescript": "^6.0.2",
         "vitest": "^4.1.4",
         "wrangler": "^4.81.1",
       },
@@ -324,6 +325,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.11",
 		"@cloudflare/vitest-pool-workers": "^0.14.3",
+		"typescript": "^6.0.2",
 		"vitest": "^4.1.4",
 		"wrangler": "^4.81.1"
 	},

--- a/src/routes/authentication.ts
+++ b/src/routes/authentication.ts
@@ -8,7 +8,7 @@ export const authentication = new Hono();
  * Parse Digest authorization header
  */
 function parseDigestAuth(authHeader: string): Record<string, string> | null {
-	if (!authHeader || !authHeader.startsWith("Digest ")) {
+	if (!authHeader?.startsWith("Digest ")) {
 		return null;
 	}
 
@@ -184,7 +184,7 @@ authentication.get("/basic-auth/:user/:passwd", async (c) => {
 
 	const authHeader = c.req.header("authorization");
 
-	if (!authHeader || !authHeader.startsWith("Basic ")) {
+	if (!authHeader?.startsWith("Basic ")) {
 		return c.body(null, 401, {
 			"WWW-Authenticate": 'Basic realm="Fake Realm"',
 		});
@@ -210,7 +210,7 @@ authentication.get("/basic-auth/:user/:passwd", async (c) => {
 authentication.get("/bearer", (c) => {
 	const authHeader = c.req.header("authorization");
 
-	if (!authHeader || !authHeader.startsWith("Bearer ")) {
+	if (!authHeader?.startsWith("Bearer ")) {
 		return c.body(null, 401, { "WWW-Authenticate": "Bearer" });
 	}
 

--- a/test/routes/cookies.test.ts
+++ b/test/routes/cookies.test.ts
@@ -275,9 +275,11 @@ describe("Cookies", () => {
 			expect(data.cookies["name"]).toBe("John Doe");
 		});
 
-		it("should handle special characters in cookie name and value", async () => {
+		it("should handle URL-encoded token characters in cookie name and value", async () => {
+			// Cookie names must be RFC 6265 `token` characters (spaces are invalid).
+			// Use percent-encoding in the path that decodes to valid tokens.
 			const res = await cookies.request(
-				"/cookies/set/test%20name/test%20value",
+				"/cookies/set/test%2Dname/test%5Fvalue",
 				{},
 				env,
 			);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI failures on the Check workflow after dependency updates.

## Root cause

1. **Typecheck**: The `check-types` script runs `tsc --noEmit`, but `typescript` was not a direct dependency, so `tsc` was missing from `node_modules/.bin` and the step failed with "command not found" (exit 127).

2. **Tests**: Newer Hono validates cookie names in `setCookie`. The test used a path segment that decoded to a name containing a space (`test%20name`), which triggers "Invalid cookie name" and a 500 response.

3. **Lint**: Biome reported `useOptionalChain` warnings in `authentication.ts`; those conditions were updated to optional chaining.

## Changes

- Add `typescript` as a devDependency and refresh `bun.lock`.
- Use optional chaining for authorization header checks in `src/routes/authentication.ts`.
- Update `test/routes/cookies.test.ts` to use percent-encoded path segments that decode to valid RFC 6265 token characters.

## Verification

Locally: `bun install --frozen-lockfile`, `bun run check`, `bun run check-types`, and `bun run test` all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-830036ad-c8c2-44a3-9dee-602a72c68bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-830036ad-c8c2-44a3-9dee-602a72c68bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

